### PR TITLE
Use a more portable date construct.

### DIFF
--- a/boot/Makefile
+++ b/boot/Makefile
@@ -7,7 +7,7 @@ clean:
 	rm -f ldr
 	rm -f *.lst *.bin *.hex *.sym
 
-DATE := $(shell date --rfc-3339=seconds)
+DATE := $(shell date +"%Y-%m-%d %H:%M:%S%z")
 GIT_VERSION := $(shell git describe --long --dirty; git show -s --format='%ci')
 %.bin: %.asm
 	cat $< | sed -e "s/@@DATE@@/$(DATE)/g" -e "s/@@GIT_VERSION@@/$(GIT_VERSION)/g" | z80asm - -o $@ --list=$(basename $@).lst --label=$(basename $@).sym $(ASM_FLAGS)

--- a/hello/Makefile
+++ b/hello/Makefile
@@ -7,7 +7,7 @@ clean:
 	rm -f ldr
 	rm -f *.lst *.bin *.hex
 
-DATE := $(shell date --rfc-3339=seconds)
+DATE := $(shell date +"%Y-%m-%d %H:%M:%S%z")
 GIT_VERSION := $(shell git describe --long --dirty; git show -s --format='%ci')
 %.bin: %.asm
 	cat $< | sed -e "s/@@DATE@@/$(DATE)/g" -e "s/@@GIT_VERSION@@/$(GIT_VERSION)/g" | z80asm - -o $@ --list=$(basename $@).lst $(ASM_FLAGS)

--- a/retro/Makefile
+++ b/retro/Makefile
@@ -5,7 +5,7 @@ all: retro.bin
 clean:
 	rm -f *.lst *.bin *.hex *.sym 
 
-DATE := $(shell date --rfc-3339=seconds)
+DATE := $(shell date +"%Y-%m-%d %H:%M:%S%z")
 #DATE := "xxx"
 GIT_VERSION := $(shell git describe --long --dirty; git show -s --format='%ci')
 %.bin: %.asm

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -6,7 +6,7 @@ clean:
 	rm -f ldr
 	rm -f *.lst *.bin *.hex *.sym
 
-DATE := $(shell date --rfc-3339=seconds)
+DATE := $(shell date +"%Y-%m-%d %H:%M:%S%z")
 GIT_VERSION := $(shell git describe --long --dirty; git show -s --format='%ci')
 
 %.bin: %.asm


### PR DESCRIPTION
The command:

    date --rfc-3339=seconds

is a GNU extension.  A much more portable date comamnd:

    date +"%Y-%m-%d %H:%M:%S%z"

uses common strftime(3) format specifiers, works on Linux, BSD, and macOS, and produces output nearly identical to the first form (differs only in the lack of a colon between the hours and minutes of the timezone offset field).

Fixes Issue #22.