### PR TITLE
Allow the default assembler of z80asm to be overridden

### DIFF
--- a/Make.default
+++ b/Make.default
@@ -17,4 +17,7 @@ ASM_FLAGS=-I../lib -I../libretro
 
 BOOT_MSG=Z80 Retro Board 2063.3
 
+# Define the assembler to use
+AS=z80asm
+
 -include $(TOP)/Make.local

--- a/boot/Makefile
+++ b/boot/Makefile
@@ -12,7 +12,7 @@ clean:
 DATE := $(shell date +"%Y-%m-%d %H:%M:%S%z")
 GIT_VERSION := $(shell git describe --long --dirty; git show -s --format='%ci')
 %.bin: %.asm
-	cat $< | sed -e "s/@@DATE@@/$(DATE)/g" -e "s/@@GIT_VERSION@@/$(GIT_VERSION)/g" -e "s/@@BOOT_MSG@@/$(BOOT_MSG)/g" | z80asm - -o $@ --list=$(basename $@).lst --label=$(basename $@).sym $(ASM_FLAGS)
+	cat $< | sed -e "s/@@DATE@@/$(DATE)/g" -e "s/@@GIT_VERSION@@/$(GIT_VERSION)/g" -e "s/@@BOOT_MSG@@/$(BOOT_MSG)/g" | $(AS) - -o $@ --list=$(basename $@).lst --label=$(basename $@).sym $(ASM_FLAGS)
 
 
 world: clean all

--- a/hello/Makefile
+++ b/hello/Makefile
@@ -11,7 +11,7 @@ clean:
 DATE := $(shell date +"%Y-%m-%d %H:%M:%S%z")
 GIT_VERSION := $(shell git describe --long --dirty; git show -s --format='%ci')
 %.bin: %.asm
-	cat $< | sed -e "s/@@DATE@@/$(DATE)/g" -e "s/@@GIT_VERSION@@/$(GIT_VERSION)/g" | z80asm - -o $@ --list=$(basename $@).lst $(ASM_FLAGS)
+	cat $< | sed -e "s/@@DATE@@/$(DATE)/g" -e "s/@@GIT_VERSION@@/$(GIT_VERSION)/g" | $(AS) - -o $@ --list=$(basename $@).lst $(ASM_FLAGS)
 
 
 world: clean all

--- a/retro/Makefile
+++ b/retro/Makefile
@@ -10,7 +10,7 @@ clean:
 DATE := $(shell date +"%Y-%m-%d %H:%M:%S%z")
 GIT_VERSION := $(shell git describe --long --dirty; git show -s --format='%ci')
 %.bin: %.asm
-	cat $< | sed -e "s/@@DATE@@/$(DATE)/g" -e "s/@@GIT_VERSION@@/$(GIT_VERSION)/g" | z80asm - -o $@ --list=$(basename $@).lst --label=$(basename $@).sym $(ASM_FLAGS)
+	cat $< | sed -e "s/@@DATE@@/$(DATE)/g" -e "s/@@GIT_VERSION@@/$(GIT_VERSION)/g" | $(AS) - -o $@ --list=$(basename $@).lst --label=$(basename $@).sym $(ASM_FLAGS)
 
 world: clean all
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -11,7 +11,7 @@ DATE := $(shell date +"%Y-%m-%d %H:%M:%S%z")
 GIT_VERSION := $(shell git describe --long --dirty; git show -s --format='%ci')
 
 %.bin: %.asm
-	cat $< | sed -e "s/@@DATE@@/$(DATE)/g" -e "s/@@GIT_VERSION@@/$(GIT_VERSION)/g" | z80asm - -o $@ --list=$(basename $@).lst --label=$(basename $@).sym $(ASM_FLAGS)
+	cat $< | sed -e "s/@@DATE@@/$(DATE)/g" -e "s/@@GIT_VERSION@@/$(GIT_VERSION)/g" | $(AS) - -o $@ --list=$(basename $@).lst --label=$(basename $@).sym $(ASM_FLAGS)
 
 
 world: clean all


### PR DESCRIPTION
Following a discussion on Discord this is a pull request to allow the default assembler to be overridden in Make.local