### PR TITLE
Fix utils makefile to use CROSS_AS Make variable

### DIFF
--- a/filesystem/utils/Makefile
+++ b/filesystem/utils/Makefile
@@ -18,7 +18,7 @@ include $(TOP)/Make.default
 .PHONY: all clean world burn blank-all-sd
 
 %.com: %.z80
-	z80asm -o $@ $^
+	$(CROSS_AS) -o $@ $^
 
 clean::
 	rm -f $(PROGS)


### PR DESCRIPTION
Xmodem builds fail when `z80asm` is different to the one expected.  The path to `z80asm` can be configured in the root level `Make.local` under `CROSS_AS`.

This change makes sure the Makefile that actually builds xmodem uses this variable.